### PR TITLE
fix: prevent process.env undefined string coercion breaking create-cart

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,9 +34,15 @@ const SHOPIFY_CUSTOMER_ACCESS_TOKEN =
   argv.customerAccessToken || process.env.SHOPIFY_CUSTOMER_ACCESS_TOKEN;
 
 // Store in process.env for backwards compatibility
-process.env.SHOPIFY_STOREFRONT_ACCESS_TOKEN = SHOPIFY_STOREFRONT_ACCESS_TOKEN;
-process.env.SHOPIFY_STORE_DOMAIN = SHOPIFY_STORE_DOMAIN;
-process.env.SHOPIFY_CUSTOMER_ACCESS_TOKEN = SHOPIFY_CUSTOMER_ACCESS_TOKEN;
+if (SHOPIFY_STOREFRONT_ACCESS_TOKEN) {
+  process.env.SHOPIFY_STOREFRONT_ACCESS_TOKEN = SHOPIFY_STOREFRONT_ACCESS_TOKEN;
+}
+if (SHOPIFY_STORE_DOMAIN) {
+  process.env.SHOPIFY_STORE_DOMAIN = SHOPIFY_STORE_DOMAIN;
+}
+if (SHOPIFY_CUSTOMER_ACCESS_TOKEN) {
+  process.env.SHOPIFY_CUSTOMER_ACCESS_TOKEN = SHOPIFY_CUSTOMER_ACCESS_TOKEN;
+}
 
 // Validate required environment variables
 // Note: Storefront access token is optional for tokenless access to products, collections, search, and carts

--- a/src/tools/createCart.ts
+++ b/src/tools/createCart.ts
@@ -50,9 +50,11 @@ export async function execute(
   client: GraphQLClient
 ): Promise<any> {
   // Determine customer access token - parameter takes precedence over environment
-  const customerAccessToken = input.customerAccessToken || 
-    input.buyerIdentity?.customerAccessToken || 
-    process.env.SHOPIFY_CUSTOMER_ACCESS_TOKEN;
+  const customerAccessToken =
+    input.customerAccessToken ||
+    input.buyerIdentity?.customerAccessToken ||
+    process.env.SHOPIFY_CUSTOMER_ACCESS_TOKEN ||
+    undefined;
 
   const query = `
     mutation CartCreate($input: CartInput!) {


### PR DESCRIPTION

```markdown
## Problem

When the MCP server is started **without** `--customerAccessToken` (the default and most common setup), every `create-cart` call fails with:

```
"Customer is invalid"
```

**Root cause**: In `src/index.ts`, assigning `undefined` to `process.env.SHOPIFY_CUSTOMER_ACCESS_TOKEN` converts it to the string `"undefined"` (truthy). Then `createCart.ts` reads this truthy string and sends it to Shopify as a customer access token, which Shopify rejects.

This is a well-documented Node.js behavior: `process.env` values are always strings, so `process.env.X = undefined` becomes `process.env.X === "undefined"`.

## Fix

**`src/index.ts`**: Guard all three `process.env` assignments with truthiness checks:

```typescript
if (SHOPIFY_STOREFRONT_ACCESS_TOKEN) {
  process.env.SHOPIFY_STOREFRONT_ACCESS_TOKEN = SHOPIFY_STOREFRONT_ACCESS_TOKEN;
}
if (SHOPIFY_STORE_DOMAIN) {
  process.env.SHOPIFY_STORE_DOMAIN = SHOPIFY_STORE_DOMAIN;
}
if (SHOPIFY_CUSTOMER_ACCESS_TOKEN) {
  process.env.SHOPIFY_CUSTOMER_ACCESS_TOKEN = SHOPIFY_CUSTOMER_ACCESS_TOKEN;
}
```

**`src/tools/createCart.ts`** (defense in depth): Add `|| undefined` fallback:

```typescript
const customerAccessToken = input.customerAccessToken ||
  input.buyerIdentity?.customerAccessToken ||
  process.env.SHOPIFY_CUSTOMER_ACCESS_TOKEN || undefined;
```

## Testing

Before fix:
1. Start server without `--customerAccessToken`
2. Call `create-cart` → fails with "Customer is invalid"

After fix:
1. Start server without `--customerAccessToken`
2. Call `create-cart` → creates anonymous cart successfully
3. Start server WITH `--customerAccessToken yourtoken`
4. Call `create-cart` → creates authenticated cart with buyer identity

## Impact

- **Critical**: Cart creation (core functionality) broken for all anonymous users
- **Affected**: Every user not passing `--customerAccessToken` (the default)
- **Scope**: Only `create-cart` directly affected, but `index.ts` fix protects all env vars